### PR TITLE
Fix navigation menu structure in _Layout.cshtml

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -18,18 +18,13 @@
                     <span class="navbar-toggler-icon"></span>
                 </button>
                 <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
-                    <ul class="navbar-nav flex-grow-1"<li class="nav-item"><a class="nav-link text-dark" asp-page="/Index">Home</a></li>
-                    <li class="nav-item"><a class="nav-link text-dark" asp-page="/Candidates/Index">Candidates</a></li>
-                    <li class="nav-item"><a class="nav-link text-dark" asp-page="/Companies/Index">Companies</a></li>
-                    <li class="nav-item"><a class="nav-link text-dark" asp-page="/JobTitles/Index">Job Titles</a></li>
-                    <li class="nav-item"><a class="nav-link text-dark" asp-page="/Industries/Index">Industries</a></li>
-                    >
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
-                        </li>
+                    <ul class="navbar-nav flex-grow-1">
+                        <li class="nav-item"><a class="nav-link text-dark" asp-page="/Index">Home</a></li>
+                        <li class="nav-item"><a class="nav-link text-dark" asp-page="/Candidates/Index">Candidates</a></li>
+                        <li class="nav-item"><a class="nav-link text-dark" asp-page="/Companies/Index">Companies</a></li>
+                        <li class="nav-item"><a class="nav-link text-dark" asp-page="/JobTitles/Index">Job Titles</a></li>
+                        <li class="nav-item"><a class="nav-link text-dark" asp-page="/Industries/Index">Industries</a></li>
+                        <li class="nav-item"><a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Restructured the navigation menu by correcting the <ul> element, removing erroneous characters, and ensuring proper closure. Retained list items for "Home," "Candidates," "Companies," "Job Titles," "Industries," and "Privacy," while improving formatting for clarity and consistency.